### PR TITLE
fix: remove wcatoken from query parameters when using @search endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.2.15 (unreleased)
 -------------------
 
+- WEB-4206 : Remove wcatoken from query parameters when using @search endpoint
+  [remdub]
+
 - WEB-4119 : Prevent removing news folder if there is at least 1 news in it
   [boulch]
 

--- a/src/imio/news/core/rest/search/endpoint.py
+++ b/src/imio/news/core/rest/search/endpoint.py
@@ -5,4 +5,5 @@ from plone.restapi.services.search.get import SearchGet as BaseSearchGet
 
 class SearchGet(BaseSearchGet):
     def reply(self):
+        self.request.form.pop("wcatoken", None)
         return super(SearchGet, self).reply()


### PR DESCRIPTION
WEB-4206